### PR TITLE
Remove hide-comment-action

### DIFF
--- a/diff/action.yaml
+++ b/diff/action.yaml
@@ -22,13 +22,6 @@ runs:
         ref: ${{ github.base_ref }}
         path: _base_ref
 
-    - uses: int128/hide-comment-action@2b9b0f2c6f482cb70511b4342744d3622f9e23eb # v1.30.0
-      with:
-        token: ${{ inputs.token }}
-        ends-with: |
-          <!-- kustomize-action -->
-          <!-- diff-action -->
-
     - uses: int128/kustomize-action@78a1dd3a437c7c1247ab7a3e053983fd56a3d956 # v1.54.0
       id: kustomize-head
       with:


### PR DESCRIPTION
Since https://github.com/int128/diff-action/releases/tag/v1.39.0, the default comment strategy has been changed to replace. No need to hide comments.