### PR TITLE
feat: Add Secret redaction functionality with content-based hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ You can add extra args to `kustomize build` command.
       --load-restrictor=LoadRestrictionsNone
 ```
 
+### Redact secrets
+
+You can redact sensitive data in Kubernetes Secrets from the build output.
+
+```yaml
+- uses: int128/kustomize-action@v1
+  with:
+    kustomization: overlays/*/kustomization.yaml
+    redact-secrets: true
+```
+
+When enabled, this will replace all values in `data` and `stringData` fields of Kubernetes Secret resources with `[REDACTED]` in the generated manifests.
+
 ## Diff between head and base ref of pull request
 
 When you open or update a pull request, you can see the diff of generated manifests between head and base ref.
@@ -157,6 +170,7 @@ See https://github.com/int128/kubebuilder-workflows/blob/v1/.github/workflows/ma
 | `max-process`            | 5              | Max number of kustomize processes                                 |
 | `write-individual-files` | `false`        | If true, write individual files                                   |
 | `ignore-kustomize-error` | `false`        | If true, ignore kustomize errors                                  |
+| `redact-secrets`         | `false`        | If true, redact sensitive data in Kubernetes Secrets             |
 | `token`                  | `github.token` | GitHub token to post a comment on error                           |
 
 ### Retry options

--- a/action.yaml
+++ b/action.yaml
@@ -34,6 +34,10 @@ inputs:
     description: If true, ignore kustomize errors
     required: true
     default: 'false'
+  redact-secrets:
+    description: If true, redact sensitive data in Kubernetes Secrets
+    required: true
+    default: 'false'
   error-comment:
     deprecationMessage: Use pretty-errors instead. See https://github.com/int128/kustomize-action#error-comment
     description: Post a comment on error

--- a/package.json
+++ b/package.json
@@ -12,16 +12,17 @@
     "@actions/exec": "1.1.1",
     "@actions/github": "6.0.1",
     "@actions/glob": "0.5.0",
-    "@actions/io": "1.1.3"
+    "@actions/io": "1.1.3",
+    "js-yaml": "4.1.0"
   },
   "devDependencies": {
     "@eslint/js": "9.32.0",
     "@tsconfig/node20": "20.1.6",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "20.19.9",
     "@vercel/ncc": "0.38.3",
     "@vitest/eslint-plugin": "1.3.4",
     "eslint": "9.32.0",
-    "js-yaml": "4.1.0",
     "pnpm": "10.14.0",
     "prettier": "3.6.2",
     "typescript": "5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@actions/io':
         specifier: 1.1.3
         version: 1.1.3
+      js-yaml:
+        specifier: 4.1.0
+        version: 4.1.0
     devDependencies:
       '@eslint/js':
         specifier: 9.32.0
@@ -30,6 +33,9 @@ importers:
       '@tsconfig/node20':
         specifier: 20.1.6
         version: 20.1.6
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: 20.19.9
         version: 20.19.9
@@ -42,9 +48,6 @@ importers:
       eslint:
         specifier: 9.32.0
         version: 9.32.0
-      js-yaml:
-        specifier: 4.1.0
-        version: 4.1.0
       pnpm:
         specifier: 10.14.0
         version: 10.14.0
@@ -471,6 +474,9 @@ packages:
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1538,6 +1544,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.7': {}
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ const main = async (): Promise<void> => {
     retryWaitMs: parseInt(core.getInput('retry-wait-ms', { required: true })),
     writeIndividualFiles: core.getBooleanInput('write-individual-files', { required: true }),
     ignoreKustomizeError: core.getBooleanInput('ignore-kustomize-error'),
+    redactSecrets: core.getBooleanInput('redact-secrets', { required: true }),
     errorComment: core.getBooleanInput('error-comment', { required: true }),
     errorCommentHeader: core.getInput('error-comment-header'),
     errorCommentFooter: core.getInput('error-comment-footer'),

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,184 @@
+// ABOUTME: This module handles redaction of sensitive data in Kubernetes Secrets
+// ABOUTME: It processes YAML files and replaces Secret data values with [REDACTED]
+
+import * as core from '@actions/core'
+import * as glob from '@actions/glob'
+import { promises as fs } from 'fs'
+import * as path from 'path'
+
+const REDACTED_VALUE = '[REDACTED]'
+
+/**
+ * Redacts sensitive data in all YAML files within the specified directory
+ */
+export const redactSecretsInDirectory = async (outputDir: string): Promise<void> => {
+  const yamlGlobber = await glob.create(path.join(outputDir, '**/*.yaml'), { matchDirectories: false })
+  const yamlFiles = await yamlGlobber.glob()
+
+  let redactedCount = 0
+  for (const yamlFile of yamlFiles) {
+    const wasRedacted = await redactSecretsInFile(yamlFile)
+    if (wasRedacted) redactedCount++
+  }
+  
+  if (redactedCount > 0) {
+    core.info(`Successfully redacted secrets in ${redactedCount} file(s)`)
+  }
+}
+
+/**
+ * Redacts sensitive data in a single YAML file
+ * @returns true if redaction was performed, false otherwise
+ */
+export const redactSecretsInFile = async (filePath: string): Promise<boolean> => {
+  try {
+    const content = await fs.readFile(filePath, 'utf8')
+    const redactedContent = redactSecretsInYaml(content)
+    
+    if (content !== redactedContent) {
+      await fs.writeFile(filePath, redactedContent, 'utf8')
+      return true
+    }
+    return false
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    core.warning(`Failed to redact secrets: ${message}`)
+    return false
+  }
+}
+
+/**
+ * Redacts sensitive data in YAML content
+ */
+export const redactSecretsInYaml = (yamlContent: string): string => {
+  // Split YAML by document separator
+  const documents = yamlContent.split(/^---$/m)
+  
+  const redactedDocuments = documents.map(doc => {
+    if (!doc.trim()) return doc
+    
+    try {
+      return redactSecretInDocument(doc)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      core.debug(`Skipping document that couldn't be processed: ${message}`)
+      return doc
+    }
+  })
+  
+  return redactedDocuments.join('---')
+}
+
+/**
+ * Redacts sensitive data in a single YAML document
+ */
+const redactSecretInDocument = (document: string): string => {  
+  // Check if this document contains a Kubernetes Secret
+  if (!isSecretDocument(document)) {
+    return document
+  }
+  
+  // Redact data and stringData fields
+  let redactedDoc = document
+  
+  // Redact data field
+  redactedDoc = redactDataField(redactedDoc, 'data')
+  
+  // Redact stringData field  
+  redactedDoc = redactDataField(redactedDoc, 'stringData')
+  
+  return redactedDoc
+}
+
+/**
+ * Checks if a YAML document represents a Kubernetes Secret
+ */
+const isSecretDocument = (document: string): boolean => {
+  return /^\s*kind:\s*Secret\s*$/m.test(document) && 
+         /^\s*apiVersion:\s*v1\s*$/m.test(document)
+}
+
+/**
+ * Redacts values in a specific data field (data or stringData)
+ */
+const redactDataField = (document: string, fieldName: string): string => {
+  const lines = document.split('\n')
+  const result: string[] = []
+  let inDataField = false
+  let dataFieldIndent = 0
+  let skipMultilineValue = false
+  let multilineKeyIndent = 0
+  
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmed = line.trim()
+    
+    // Check if we're starting the target field
+    if (new RegExp(`^\\s*${fieldName}:\\s*$`).test(line)) {
+      inDataField = true
+      dataFieldIndent = line.length - line.trimStart().length
+      result.push(line)
+      continue
+    }
+    
+    // If we're in the data field
+    if (inDataField) {
+      const lineIndent = line.length - line.trimStart().length
+      
+      // If line has same or less indentation than field declaration, we're out of the field
+      if (trimmed && lineIndent <= dataFieldIndent) {
+        inDataField = false
+        skipMultilineValue = false
+        result.push(line)
+        continue
+      }
+      
+      // Skip empty lines within data field
+      if (!trimmed) {
+        if (!skipMultilineValue) {
+          result.push(line)
+        }
+        continue
+      }
+      
+      // If we're skipping multiline content, check if this line is still part of it
+      if (skipMultilineValue && lineIndent > multilineKeyIndent) {
+        // Skip lines that are part of a multiline value
+        continue
+      }
+      
+      // Check if this is a key-value pair (contains colon and is at the correct indentation level)
+      if (trimmed.includes(':') && !skipMultilineValue) {
+        const colonIndex = line.indexOf(':')
+        const key = line.substring(0, colonIndex)
+        const valueStart = line.substring(colonIndex + 1).trim()
+        
+        // Replace the value with [REDACTED]
+        result.push(`${key}: ${REDACTED_VALUE}`)
+        
+        // Check if this is a multiline value (|, >, etc)
+        if (valueStart.match(/^[|>-]/)) {
+          skipMultilineValue = true
+          multilineKeyIndent = lineIndent
+        } else {
+          skipMultilineValue = false
+        }
+      } else {
+        // If we're not in a multiline value, this might be a regular line
+        if (!skipMultilineValue) {
+          result.push(line)
+        }
+        // If we are in a multiline value but the indentation suggests we're out of it
+        else if (lineIndent <= multilineKeyIndent) {
+          skipMultilineValue = false
+          result.push(line)
+        }
+      }
+    } else {
+      // Not in data field, keep line as is
+      result.push(line)
+    }
+  }
+  
+  return result.join('\n')
+}

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -155,6 +155,11 @@ const redactDataField = (document: string, fieldName: string): string => {
         continue
       }
       
+      // If we're in skipMultilineValue but encounter a new key-value pair at same/lower indent, reset state
+      if (skipMultilineValue && lineIndent <= multilineKeyIndent && trimmed.includes(':')) {
+        skipMultilineValue = false
+      }
+      
       // Check if this is a key-value pair (contains colon and is at the correct indentation level)
       if (trimmed.includes(':') && !skipMultilineValue) {
         const colonIndex = line.indexOf(':')

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -115,7 +115,7 @@ const redactSecretInDocument = (document: string): string => {
       lineWidth: -1, 
       forceQuotes: false,
       flowLevel: -1
-    }).trim()
+    }).trimEnd()
     
     // Remove quotes around redacted values to match expected format
     result = result.replace(/["'](\[REDACTED-[a-f0-9]{8}\])["']/g, '$1')

--- a/src/run.ts
+++ b/src/run.ts
@@ -7,6 +7,7 @@ import { globKustomization } from './glob.js'
 import { KustomizeBuildOption, KustomizeError, kustomizeBuild } from './build.js'
 import { copyExtraFiles } from './copy.js'
 import { commentErrors, formatErrors } from './comment.js'
+import { redactSecretsInDirectory } from './redact.js'
 import * as kustomize from './kustomize.js'
 
 type Inputs = {
@@ -14,6 +15,7 @@ type Inputs = {
   extraFiles: string
   baseDir: string
   ignoreKustomizeError: boolean
+  redactSecrets: boolean
   errorComment: boolean
   errorCommentHeader: string
   errorCommentFooter: string
@@ -40,6 +42,10 @@ export const run = async (inputs: Inputs): Promise<void> => {
       header: inputs.errorCommentHeader,
       footer: inputs.errorCommentFooter,
     })
+  }
+
+  if (inputs.redactSecrets) {
+    await core.group('Redacting secrets', async () => await redactSecretsInDirectory(outputBaseDir))
   }
 
   await core.group('Copying the extra files', async () => await copyExtraFiles(inputs.extraFiles, outputBaseDir))

--- a/tests/fixtures/test-secret.yaml
+++ b/tests/fixtures/test-secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: default
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+stringData:
+  config.json: |
+    {
+      "api_key": "secret-key",
+      "database_url": "postgres://user:pass@localhost/db"
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -123,8 +123,9 @@ data: # This is a comment
   sso-issuer: aHR0cHM6Ly9leGFtcGxlLmNvbQ==`
 
     const result = redactSecretsInYaml(yamlContent)
-    // Should not redact because regex doesn't match data field with comment
-    expect(result).toContain('aHR0cHM6Ly9leGFtcGxlLmNvbQ==')
+    // With js-yaml parser, comments are handled correctly and data is redacted
+    expect(result).toMatch(/sso-issuer: \[REDACTED-[a-f0-9]{8}\]/)
+    expect(result).not.toContain('aHR0cHM6Ly9leGFtcGxlLmNvbQ==')
   })
 
   it('should handle incorrect indentation', () => {

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -1,0 +1,463 @@
+import { it, expect, vi, describe, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import { redactSecretsInYaml, redactSecretsInFile, redactSecretsInDirectory } from '../src/redact.js'
+
+vi.mock('@actions/core') // suppress logs
+
+describe('redactSecretsInYaml', () => {
+  it('should redact data fields in Kubernetes Secret', () => {
+    const yamlContent = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+  api-key: c29tZS1hcGkta2V5`
+
+    const expected = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+data:
+  username: [REDACTED]
+  password: [REDACTED]
+  api-key: [REDACTED]`
+
+    const result = redactSecretsInYaml(yamlContent)
+    expect(result).toBe(expected)
+  })
+
+  it('should redact stringData fields in Kubernetes Secret', () => {
+    const yamlContent = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+stringData:
+  username: admin
+  password: secret123
+  config.yaml: |
+    key: value
+    secret: confidential`
+
+    const expected = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+stringData:
+  username: [REDACTED]
+  password: [REDACTED]
+  config.yaml: [REDACTED]`
+
+    const result = redactSecretsInYaml(yamlContent)
+    expect(result).toBe(expected)
+  })
+
+  it('should redact both data and stringData fields', () => {
+    const yamlContent = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  encoded: YWRtaW4=
+stringData:
+  plain: admin`
+
+    const expected = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  encoded: [REDACTED]
+stringData:
+  plain: [REDACTED]`
+
+    const result = redactSecretsInYaml(yamlContent)
+    expect(result).toBe(expected)
+  })
+
+  it('should not modify non-Secret resources', () => {
+    const yamlContent = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: app
+        image: nginx:latest
+        env:
+        - name: SECRET_KEY
+          value: should-not-be-redacted`
+
+    const result = redactSecretsInYaml(yamlContent)
+    expect(result).toBe(yamlContent)
+  })
+
+  it('should handle multi-document YAML', () => {
+    const yamlContent = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  password: c2VjcmV0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service`
+
+    const expected = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  password: [REDACTED]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service`
+
+    const result = redactSecretsInYaml(yamlContent)
+    expect(result).toBe(expected)
+  })
+
+  it('should handle Secret without data fields', () => {
+    const yamlContent = `apiVersion: v1
+kind: Secret
+metadata:
+  name: empty-secret
+type: Opaque`
+
+    const result = redactSecretsInYaml(yamlContent)
+    expect(result).toBe(yamlContent)
+  })
+
+  it('should handle malformed YAML gracefully', () => {
+    const yamlContent = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  invalid yaml: [unclosed bracket`
+
+    const expected = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  invalid yaml: [REDACTED]`
+
+    // Should not throw and still redact what it can process
+    const result = redactSecretsInYaml(yamlContent)
+    expect(result).toBe(expected)
+  })
+})
+
+describe('file operations', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'redact-test-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('should redact secrets in a file', async () => {
+    const yamlContent = `apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+data:
+  password: c2VjcmV0`
+
+    const filePath = path.join(tempDir, 'secret.yaml')
+    await fs.writeFile(filePath, yamlContent, 'utf8')
+
+    await redactSecretsInFile(filePath)
+
+    const result = await fs.readFile(filePath, 'utf8')
+    expect(result).toContain('password: [REDACTED]')
+  })
+
+  it('should not modify non-secret files', async () => {
+    const yamlContent = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app`
+
+    const filePath = path.join(tempDir, 'deployment.yaml')
+    await fs.writeFile(filePath, yamlContent, 'utf8')
+
+    await redactSecretsInFile(filePath)
+
+    const result = await fs.readFile(filePath, 'utf8')
+    expect(result).toBe(yamlContent)
+  })
+
+  it('should redact secrets in all files in directory', async () => {
+    // Create multiple files with secrets
+    const secretYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: secret1
+data:
+  key: dmFsdWU=`
+
+    const deploymentYaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app`
+
+    const secret2Yaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: secret2
+stringData:
+  config: sensitive-data`
+
+    await fs.writeFile(path.join(tempDir, 'secret1.yaml'), secretYaml, 'utf8')
+    await fs.writeFile(path.join(tempDir, 'deployment.yaml'), deploymentYaml, 'utf8')
+    await fs.writeFile(path.join(tempDir, 'secret2.yaml'), secret2Yaml, 'utf8')
+
+    await redactSecretsInDirectory(tempDir)
+
+    // Check that secrets were redacted
+    const secret1Result = await fs.readFile(path.join(tempDir, 'secret1.yaml'), 'utf8')
+    expect(secret1Result).toContain('key: [REDACTED]')
+
+    const secret2Result = await fs.readFile(path.join(tempDir, 'secret2.yaml'), 'utf8')
+    expect(secret2Result).toContain('config: [REDACTED]')
+
+    // Check that deployment was not modified
+    const deploymentResult = await fs.readFile(path.join(tempDir, 'deployment.yaml'), 'utf8')
+    expect(deploymentResult).toBe(deploymentYaml)
+  })
+
+  it('should handle nested directories', async () => {
+    const nestedDir = path.join(tempDir, 'nested')
+    await fs.mkdir(nestedDir)
+
+    const secretYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: nested-secret
+data:
+  token: dG9rZW4=`
+
+    await fs.writeFile(path.join(nestedDir, 'secret.yaml'), secretYaml, 'utf8')
+
+    await redactSecretsInDirectory(tempDir)
+
+    const result = await fs.readFile(path.join(nestedDir, 'secret.yaml'), 'utf8')
+    expect(result).toContain('token: [REDACTED]')
+  })
+
+  it('should handle file read errors gracefully', async () => {
+    const nonExistentFile = path.join(tempDir, 'does-not-exist.yaml')
+    
+    // Should not throw error and return false
+    const result = await redactSecretsInFile(nonExistentFile)
+    expect(result).toBe(false)
+  })
+
+  it('should handle file write permission errors gracefully', async () => {
+    const secretYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+data:
+  key: value`
+
+    const filePath = path.join(tempDir, 'readonly-secret.yaml')
+    await fs.writeFile(filePath, secretYaml, 'utf8')
+    
+    // Make file read-only
+    await fs.chmod(filePath, 0o444)
+
+    // Should handle the error gracefully and return false
+    const result = await redactSecretsInFile(filePath)
+    expect(result).toBe(false)
+    
+    // Restore permissions for cleanup
+    await fs.chmod(filePath, 0o644)
+  })
+})
+
+describe('additional edge cases', () => {
+  it('should handle different Secret types', () => {
+    const tlsSecretYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: tls-secret
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTi...
+  tls.key: LS0tLS1CRUdJTi...`
+
+    const expected = `apiVersion: v1
+kind: Secret
+metadata:
+  name: tls-secret
+type: kubernetes.io/tls
+data:
+  tls.crt: [REDACTED]
+  tls.key: [REDACTED]`
+
+    const result = redactSecretsInYaml(tlsSecretYaml)
+    expect(result).toBe(expected)
+  })
+
+  it('should handle docker config Secret type', () => {
+    const dockerSecretYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-secret
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: eyJhdXRocyI6e319`
+
+    const expected = `apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-secret
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: [REDACTED]`
+
+    const result = redactSecretsInYaml(dockerSecretYaml)
+    expect(result).toBe(expected)
+  })
+
+  it('should handle empty data and stringData fields', () => {
+    const emptySecretYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: empty-secret
+data: {}
+stringData: {}`
+
+    const result = redactSecretsInYaml(emptySecretYaml)
+    expect(result).toBe(emptySecretYaml) // Should not change anything
+  })
+
+  it('should handle keys with special characters', () => {
+    const specialKeySecretYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: special-keys
+data:
+  my-key.with-dots: dmFsdWU=
+  key_with_underscores: dmFsdWU=
+  "key with spaces": dmFsdWU=
+  key@with@symbols: dmFsdWU=`
+
+    const expected = `apiVersion: v1
+kind: Secret
+metadata:
+  name: special-keys
+data:
+  my-key.with-dots: [REDACTED]
+  key_with_underscores: [REDACTED]
+  "key with spaces": [REDACTED]
+  key@with@symbols: [REDACTED]`
+
+    const result = redactSecretsInYaml(specialKeySecretYaml)
+    expect(result).toBe(expected)
+  })
+
+  it('should preserve YAML comments', () => {
+    const commentedSecretYaml = `# This is a secret for authentication
+apiVersion: v1
+kind: Secret
+metadata:
+  name: commented-secret
+  # This contains sensitive data
+data:
+  # Base64 encoded username
+  username: YWRtaW4=
+  # Base64 encoded password  
+  password: cGFzcw==`
+
+    const result = redactSecretsInYaml(commentedSecretYaml)
+    
+    // Should preserve comments
+    expect(result).toContain('# This is a secret for authentication')
+    expect(result).toContain('# This contains sensitive data')
+    expect(result).toContain('# Base64 encoded username')
+    expect(result).toContain('# Base64 encoded password')
+    
+    // Should redact values
+    expect(result).toContain('username: [REDACTED]')
+    expect(result).toContain('password: [REDACTED]')
+  })
+
+  it('should handle multiple Secrets in same document', () => {
+    const multipleSecretsYaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: secret1
+data:
+  key1: dmFsdWUx
+---
+apiVersion: v1
+kind: Secret  
+metadata:
+  name: secret2
+stringData:
+  key2: value2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app`
+
+    const result = redactSecretsInYaml(multipleSecretsYaml)
+    
+    expect(result).toContain('key1: [REDACTED]')
+    expect(result).toContain('key2: [REDACTED]')
+    expect(result).toContain('kind: Deployment') // Should preserve non-Secret
+  })
+
+  it('should handle incorrect Secret identification', () => {
+    // Missing apiVersion
+    const missingApiVersionYaml = `kind: Secret
+metadata:
+  name: invalid-secret
+data:
+  key: value`
+
+    const result1 = redactSecretsInYaml(missingApiVersionYaml)
+    expect(result1).toBe(missingApiVersionYaml) // Should not redact
+
+    // Wrong apiVersion
+    const wrongApiVersionYaml = `apiVersion: apps/v1
+kind: Secret
+metadata:
+  name: invalid-secret
+data:
+  key: value`
+
+    const result2 = redactSecretsInYaml(wrongApiVersionYaml)
+    expect(result2).toBe(wrongApiVersionYaml) // Should not redact
+  })
+})


### PR DESCRIPTION
  This PR introduces Secret redaction functionality to the Kustomize action.

  ## Changes
  - **New Feature**: Implements Secret resource redaction with content-based hashing to ensure consistent
  output while protecting sensitive data
  - **Robust YAML Processing**: Integrates js-yaml library for reliable parsing, replacing manual string
  manipulation

  ## Files Modified
  - Added `src/redact.ts` with core redaction logic
  - Updated action configuration and dependencies
  - Added comprehensive test suite with fixtures
  - Updated documentation